### PR TITLE
カセット画像をタップすると背面のセトリが表示できるように

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/dena/autum_hackathon_b/cassette/MainActivity.kt
+++ b/app/src/main/java/com/dena/autum_hackathon_b/cassette/MainActivity.kt
@@ -31,7 +31,7 @@ class MainActivity : ComponentActivity() {
             CassetteTheme {
                 NavHost(navController = navController, startDestination = "play") {
                     composable(route = "play") {
-                        PlayScreenHost(
+                       PlayScreenHost(
                             navigateToCreateScreen = {
                                 navController.navigate("create")
                             }

--- a/app/src/main/java/com/dena/autum_hackathon_b/cassette/MainActivity.kt
+++ b/app/src/main/java/com/dena/autum_hackathon_b/cassette/MainActivity.kt
@@ -31,7 +31,7 @@ class MainActivity : ComponentActivity() {
             CassetteTheme {
                 NavHost(navController = navController, startDestination = "play") {
                     composable(route = "play") {
-                       PlayScreenHost(
+                        PlayScreenHost(
                             navigateToCreateScreen = {
                                 navController.navigate("create")
                             }

--- a/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/PlayScreen.kt
+++ b/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/PlayScreen.kt
@@ -33,6 +33,10 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.dena.autum_hackathon_b.cassette.R
 import androidx.media3.exoplayer.ExoPlayer
+import com.dena.autum_hackathon_b.cassette.feature.create.CreateScreenState
+import com.dena.autum_hackathon_b.cassette.feature.create.CreateScreenViewModel
+import com.dena.autum_hackathon_b.cassette.feature.create.Song
+import com.dena.autum_hackathon_b.cassette.feature.create.rememberCreateScreenState
 import com.dena.autum_hackathon_b.cassette.feature.play.flipping.FlippingCassetteImage
 import com.dena.autum_hackathon_b.cassette.ui.theme.CassetteTheme
 
@@ -101,7 +105,8 @@ fun PlayScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
-                    .padding(top = 16.dp, bottom = 30.dp)
+                    .padding(top = 16.dp, bottom = 30.dp),
+                screenState = screenState,
             )
 
             Text(
@@ -162,7 +167,6 @@ private fun PreviewPlayScreen() {
     val exoPlayer = remember(context) {
         ExoPlayer.Builder(context).build()
     }
-
     CassetteTheme {
         PlayScreen(screenState = PlayScreenState(screenState, exoPlayer), onClickAddButton = {})
     }

--- a/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/PlayScreen.kt
+++ b/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/PlayScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.dena.autum_hackathon_b.cassette.R
 import androidx.media3.exoplayer.ExoPlayer
+import com.dena.autum_hackathon_b.cassette.feature.play.flipping.FlippingCassetteImage
 import com.dena.autum_hackathon_b.cassette.ui.theme.CassetteTheme
 
 @Composable
@@ -96,9 +97,8 @@ fun PlayScreen(modifier: Modifier = Modifier, screenState: PlayScreenState) {
                 textAlign = TextAlign.Center,
             )
              */
-            Image(
-                painter = painterResource(id = R.drawable.cassette_image),
-                contentDescription = "Figure Image",
+            // フリップ可能なカセット画像を表示
+            FlippingCassetteImage(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)

--- a/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/PlayScreenState.kt
+++ b/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/PlayScreenState.kt
@@ -3,14 +3,49 @@ package com.dena.autum_hackathon_b.cassette.feature.play
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.media3.exoplayer.ExoPlayer
+
+sealed interface Song {
+    data class AddedSong(
+        val duration: String,
+        val name: String,
+        val audioFileUrl: String,
+    ) : Song
+}
 
 @Stable
 class PlayScreenState(private val uiState: State<UiState>, private val exoPlayer: ExoPlayer) {
     val cassetteId: String
         get() = uiState.value.cassetteId ?: ""
+
+    val songs: List<Song>
+        get() = listOf(
+            // TODO: サーバーから取ってきたカセットの情報（UiState）をここで表示
+            Song.AddedSong(
+                duration = "0:00",
+                name = "ウタ1",
+                audioFileUrl = "https://example.com/song1.mp3"
+            ),
+            Song.AddedSong(
+                duration = "0:30",
+                name = "ウタ2",
+                audioFileUrl = "https://example.com/song2.mp3"
+            ),
+            Song.AddedSong(
+                duration = "1:30",
+                name = "ウタ3",
+                audioFileUrl = "https://example.com/song3.mp3"
+            ),
+        )
+
+    val totalDuration: String
+        get() = "10:00"
+
 }
 
 @Composable

--- a/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/flipping/flippingAnimation.kt
+++ b/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/flipping/flippingAnimation.kt
@@ -1,0 +1,68 @@
+package com.dena.autum_hackathon_b.cassette.feature.play.flipping
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.dena.autum_hackathon_b.cassette.R
+
+@Composable
+fun FlippingCassetteImage(
+    modifier: Modifier = Modifier
+){
+        var isFlipped by remember {mutableStateOf(false) }
+
+        val rotation by animateFloatAsState(
+            targetValue = if (isFlipped) 180f else 0f,
+            animationSpec = tween(
+                durationMillis = 600,
+                easing = FastOutSlowInEasing
+            )
+        )
+
+    val isBackVisible = rotation > 90f
+
+    Box(
+        modifier = modifier
+            .graphicsLayer {
+                rotationY = rotation
+                cameraDistance = 12f * density
+            }
+            .clickable {
+                isFlipped = !isFlipped
+            }
+    ){
+        if(isBackVisible){
+            Image(
+                painter = painterResource(id = R.drawable.cassette_image),
+                contentDescription = "Cassette back",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp, bottom = 30.dp)
+            )
+        }
+        else {
+            Image(
+                painter = painterResource(id = R.drawable.cassette_image),
+                contentDescription = "Cassette front",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp, bottom = 30.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/flipping/flippingAnimation.kt
+++ b/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/flipping/flippingAnimation.kt
@@ -4,11 +4,24 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -17,14 +30,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.dena.autum_hackathon_b.cassette.R
+import com.dena.autum_hackathon_b.cassette.feature.play.PlayScreenState
+import com.dena.autum_hackathon_b.cassette.feature.play.Song
 
 @Composable
 fun FlippingCassetteImage(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    screenState: PlayScreenState
 ) {
     var isFlipped by remember { mutableStateOf(false) }
 
@@ -51,16 +70,54 @@ fun FlippingCassetteImage(
         contentAlignment = Alignment.Center
     ) {
         if (isBackVisible) {
-            Text("aaaaaaaaaaaaaaaa")
-            /*
-            Image(
-                painter = painterResource(id = R.drawable.cassette_image),
-                contentDescription = "Cassette back",
+
+            val layoutDirection = LocalLayoutDirection.current
+
+            LazyColumn(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp, bottom = 30.dp)
-            )
-             */
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                /*
+                contentPadding = PaddingValues(
+                    start = innerPadding.calculateStartPadding(layoutDirection) + 16.dp,
+                    top = innerPadding.calculateTopPadding() + 16.dp,
+                    end = innerPadding.calculateEndPadding(layoutDirection) + 16.dp,
+                    bottom = innerPadding.calculateBottomPadding() + 96.dp
+                )
+                 */
+            ) {
+                itemsIndexed(screenState.songs) { index, song ->
+                    Box(
+                        modifier = Modifier
+                            .clip(
+                                shape = when (index) {
+                                    0 -> RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp)
+                                    screenState.songs.size - 1 -> RoundedCornerShape(
+                                        bottomStart = 8.dp,
+                                        bottomEnd = 8.dp
+                                    )
+
+                                    else -> RectangleShape
+                                }
+                            )
+                            .background(color = MaterialTheme.colorScheme.surfaceVariant)
+                    ) {
+                        when (song) {
+                            is Song.AddedSong -> AddedSongRow(
+                                index = index,
+                                size = screenState.songs.size,
+                                song = song
+                            )
+                        }
+                        if (index != 0) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(horizontal = 8.dp),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
         } else {
             Image(
                 painter = painterResource(id = R.drawable.cassette_image),
@@ -70,5 +127,19 @@ fun FlippingCassetteImage(
                     .padding(top = 16.dp, bottom = 30.dp)
             )
         }
+    }
+}
+
+@Composable
+fun AddedSongRow(modifier: Modifier = Modifier, size: Int, index: Int, song: Song.AddedSong) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp, horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(text = song.duration)
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = song.name)
     }
 }

--- a/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/flipping/flippingAnimation.kt
+++ b/app/src/main/java/com/dena/autum_hackathon_b/cassette/feature/play/flipping/flippingAnimation.kt
@@ -9,11 +9,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
@@ -23,16 +25,16 @@ import com.dena.autum_hackathon_b.cassette.R
 @Composable
 fun FlippingCassetteImage(
     modifier: Modifier = Modifier
-){
-        var isFlipped by remember {mutableStateOf(false) }
+) {
+    var isFlipped by remember { mutableStateOf(false) }
 
-        val rotation by animateFloatAsState(
-            targetValue = if (isFlipped) 180f else 0f,
-            animationSpec = tween(
-                durationMillis = 600,
-                easing = FastOutSlowInEasing
-            )
+    val rotation by animateFloatAsState(
+        targetValue = if (isFlipped) 180f else 0f,
+        animationSpec = tween(
+            durationMillis = 600,
+            easing = FastOutSlowInEasing
         )
+    )
 
     val isBackVisible = rotation > 90f
 
@@ -41,12 +43,16 @@ fun FlippingCassetteImage(
             .graphicsLayer {
                 rotationY = rotation
                 cameraDistance = 12f * density
+                scaleX = if (rotation in 90f..270f) -1f else 1f
             }
             .clickable {
                 isFlipped = !isFlipped
-            }
-    ){
-        if(isBackVisible){
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        if (isBackVisible) {
+            Text("aaaaaaaaaaaaaaaa")
+            /*
             Image(
                 painter = painterResource(id = R.drawable.cassette_image),
                 contentDescription = "Cassette back",
@@ -54,8 +60,8 @@ fun FlippingCassetteImage(
                     .fillMaxWidth()
                     .padding(top = 16.dp, bottom = 30.dp)
             )
-        }
-        else {
+             */
+        } else {
             Image(
                 painter = painterResource(id = R.drawable.cassette_image),
                 contentDescription = "Cassette front",


### PR DESCRIPTION
- カセット画像をタップすると表裏反転
- 背面ではセトリを表示
Close #7 


https://github.com/user-attachments/assets/71bbd091-0c90-430a-aa33-e0e0723e691b

